### PR TITLE
Fix performance drop and inconsistencies when using TipA

### DIFF
--- a/scripts/adapt.sh
+++ b/scripts/adapt.sh
@@ -9,7 +9,7 @@ DATASET=$2      # target dataset - i.e. {imagenet, caltech101, oxford_pets, stan
                 #                        fgvc_aircraft, sun397, dtd, eurosat, ucf101}
 CFG=$3          # config file - SGD_lr1e-1_B256_ep300
 SHOTS=$4        # number of shots (1, 2, 4, 8, 16)
-INIT=$5         # Method / Linear Probe init - i.e. {RANDOM, ZS, ClipA, TipA, TipA(f), TR, TRenh}
+INIT=$5         # Method / Linear Probe init - i.e. {RANDOM, ZS, ClipA, TipA, TipA-f-, TR, TRenh}
 CONSTRAINT=$6   # apply class-adaptive constraint in Linear Probing (CLAP) - i.e. {none, l2}
 BACKBONE=$7     # CLIP backbone to sue - i.e. {RN50, RN101, ViT-B/32, ViT-B/16}
 

--- a/train.py
+++ b/train.py
@@ -74,7 +74,9 @@ def reset_cfg(cfg, args):
     if args.head:
         cfg.MODEL.HEAD.NAME = args.head
 
-
+    if args.train_sampler:
+        cfg.DATALOADER.TRAIN_X.SAMPLER = args.train_sampler
+        
 def extend_cfg(cfg):
     """
     Add new config variables.
@@ -202,5 +204,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "--enhanced-base", type=str, default="none", help="path to enhanced base classifier weight"
     )   # "none" means without using enhanced base
+    parser.add_argument(
+        "--train-sampler", type=str, default="RandomSampler", help="When training with TipA/TipA-f-, use SequentialSampler to replace the default RandomSampler to fix the order of train set",
+    )
     args = parser.parse_args()
     main(args)

--- a/trainers/adapters.py
+++ b/trainers/adapters.py
@@ -191,9 +191,6 @@ class AdapterMethod(nn.Module):
         ).to(self.device)
 
     def init_tipA(self, beta=1, alpha=1):
-        # We found performance drop and inconsistencies when using augmentations on TipA
-        self.epochs_aumentation, self.augmentations = 1, False
-
         if "-f-" in self.initialization:
             self.grid_search_param = {"lr": [1e-1, 1e-2],
                                       "alpha": list(np.arange(1, 50, 50/10)),
@@ -824,9 +821,9 @@ class ADAPTER(TrainerXCostume):
                         labels_ds.append(label), logits_ds.append(logits.cpu()),  features_ds.append(features.cpu())
 
             # Concatenate outputs
-            labels_ds = torch.concat(labels_ds, dim=0)
-            logits_ds = torch.concat(logits_ds, dim=0)
-            features_ds = torch.concat(features_ds, dim=0)
+            labels_ds = torch.cat(labels_ds, dim=0)
+            logits_ds = torch.cat(logits_ds, dim=0)
+            features_ds = torch.cat(features_ds, dim=0)
 
         else:
 
@@ -839,17 +836,17 @@ class ADAPTER(TrainerXCostume):
                         logits, features = self.model(input, return_features=True)
                         labels_ds_irep.append(label), logits_dsirep.append(logits.cpu()), features_ds_irep.append(features.cpu())
                 # Concatenate outputs for dataset
-                labels_ds_irep = torch.concat(labels_ds_irep, dim=0)
-                logits_dsirep = torch.concat(logits_dsirep, dim=0)
-                features_ds_irep = torch.concat(features_ds_irep, dim=0)
+                labels_ds_irep = torch.cat(labels_ds_irep, dim=0)
+                logits_dsirep = torch.cat(logits_dsirep, dim=0)
+                features_ds_irep = torch.cat(features_ds_irep, dim=0)
                 # Concatenate outputs for repetitons
                 labels_ds.append(labels_ds_irep.unsqueeze(0))
                 logits_ds.append(logits_dsirep.unsqueeze(0))
                 features_ds.append(features_ds_irep.unsqueeze(0))
 
             # Concatenate outputs
-            labels_ds = torch.concat(labels_ds, dim=0)[0, :]
-            logits_ds = torch.concat(logits_ds, dim=0).mean(0)
-            features_ds = torch.concat(features_ds, dim=0).mean(0)
+            labels_ds = torch.cat(labels_ds, dim=0)[0, :]
+            logits_ds = torch.cat(logits_ds, dim=0).mean(0)
+            features_ds = torch.cat(features_ds, dim=0).mean(0)
 
         return labels_ds, logits_ds, features_ds


### PR DESCRIPTION
Hello! Great work!

I noticed that the TipA method in the repo has a performance degradation problem when using data augmentation. After carefully checking the code, I found that it was due to the wrong averaging operation in the following codes:
```
                ...
                # Concatenate outputs for repetitons
                labels_ds.append(labels_ds_irep.unsqueeze(0))
                logits_ds.append(logits_dsirep.unsqueeze(0))
                features_ds.append(features_ds_irep.unsqueeze(0))

            # Concatenate outputs
            labels_ds = torch.cat(labels_ds, dim=0)[0, :]
            logits_ds = torch.cat(logits_ds, dim=0).mean(0)
            features_ds = torch.cat(features_ds, dim=0).mean(0)
```
 In short, all objects contained in `features_ds_irep` list should have the same order and correspond strictly.

To maintain consistency with the original repository, I added the following code and kept the default value unchanged.

```
    parser.add_argument(
        "--train-sampler", type=str, default="RandomSampler", help="When training with TipA/TipA-f-, use SequentialSampler to replace the default RandomSampler to fix the order of train set",
    )
```
When using TipA method, the value of the parameter `train-sampler` should be set to `SequentialSampler` (default is `RandomSampler`). Finally, run the code, and we will see a significant performance improvement! :smiley:

At the same time, I also fixed some other small bugs. For example, the `torch.concat()` function was abandoned in later versions and replaced by `torch.cat()`.